### PR TITLE
feat: improve mock framework (#7)

### DIFF
--- a/perm/perm.go
+++ b/perm/perm.go
@@ -47,7 +47,7 @@ func (p *Test) Test(t *test.TestingT, perm []string, expect test.Expect) {
 	case test.ExpectSuccess:
 		// Test proper usage of `WaitGroup` on non-failing validation.
 		p.TestPerm(t, perm)
-		p.mocks.WaitGroup().Wait()
+		p.mocks.Wait()
 	case test.ExpectFailure:
 		// we need to execute failing test synchronous, since we setup full
 		// permutations instead of stopping setup on first failing mock calls.

--- a/perm/perm_test.go
+++ b/perm/perm_test.go
@@ -20,12 +20,9 @@ type IFace interface {
 
 func CallA(input string) mock.SetupFunc {
 	return func(mocks *mock.Mocks) any {
-		mocks.WaitGroup().Add(1)
 		return mock.Get(mocks, NewMockIFace).EXPECT().
-			CallA(input).Times(1).
-			Do(func(arg any) {
-				defer mocks.WaitGroup().Done()
-			})
+			CallA(input).Times(mocks.Times(1)).
+			Do(mocks.GetDone(1))
 	}
 }
 

--- a/sync/waitgroup.go
+++ b/sync/waitgroup.go
@@ -1,0 +1,73 @@
+package sync
+
+import "sync"
+
+// WaitGroup interface of a wait group as provided by `sync.WaitGroup`.
+type WaitGroup interface {
+	// Add increments or decrements the wait counter by the given delta.
+	Add(delta int)
+	// Done decrements the wait counter by exactly one.
+	Done()
+	// Wait waits until the wait counter has returned to zero.
+	Wait()
+}
+
+// Synchronizer is an interface to setup the wait group of a component.
+type Synchronizer interface {
+	WaitGroup(WaitGroup)
+}
+
+// NewWaitGroup creates a new standard wait group.
+func NewWaitGroup() WaitGroup {
+	return &sync.WaitGroup{}
+}
+
+// LenientWaitGroup implements a lenient wait group for testing purposes based
+// on a `sync.WaitGroup` that allows breaking the barrier by consuming the wait
+// group counter completely without creating panics in consuming components.
+type LenientWaitGroup struct {
+	wg sync.WaitGroup
+}
+
+// NewLenientWaitGroup implements a lenient wait group for testing purposes
+// based on a `sync.WaitGroup` that allows breaking the barrier by consuming
+// the wait group counter completely without creating panics in consuming
+// components.
+func NewLenientWaitGroup() WaitGroup {
+	return &LenientWaitGroup{}
+}
+
+// Add increments or decrements the wait group counter leniently by the delta,
+// i.e. it does not fail, if the wait group counter is already consumed.
+func (wg *LenientWaitGroup) Add(delta int) {
+	if delta > 0 {
+		wg.wg.Add(delta)
+	} else {
+		defer func() {
+			if err := recover(); err != nil &&
+				err.(string) == "sync: negative WaitGroup counter" {
+				wg.wg.Add(1)
+			}
+		}()
+		for d := delta; d < 0; d++ {
+			wg.wg.Done()
+		}
+	}
+}
+
+// Done decrements the wait group counter leniently by one, i.e. it does not
+// fail, if the wait group counter is already consumed.
+func (wg *LenientWaitGroup) Done() {
+	defer func() {
+		if err := recover(); err != nil &&
+			err.(string) == "sync: negative WaitGroup counter" {
+			wg.wg.Add(1)
+		}
+	}()
+	wg.wg.Done()
+}
+
+// Wait waits until the work group counter is completely consumed.
+func (wg *LenientWaitGroup) Wait() {
+	wg.wg.Wait()
+}

--- a/sync/waitgroup_test.go
+++ b/sync/waitgroup_test.go
@@ -1,0 +1,37 @@
+package sync
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitGroup(t *testing.T) {
+	defer func() { recover() }()
+	// Given
+	wg := NewWaitGroup()
+
+	// When
+	wg.Add(3)
+	wg.Done()
+	wg.Add(math.MinInt32)
+	wg.Done()
+
+	// Then
+	assert.Fail(t, "not recovered from panic")
+}
+
+func TestLenientWaitGroup(t *testing.T) {
+	// Given
+	wg := NewLenientWaitGroup()
+
+	// When
+	wg.Add(3)
+	wg.Done()
+	wg.Add(math.MinInt32)
+	wg.Done()
+
+	// Then
+	wg.Wait()
+}

--- a/test/testing.go
+++ b/test/testing.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"math"
 	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tkrop/testing/mock"
+	"github.com/tkrop/testing/sync"
 )
 
 const (
@@ -36,8 +35,9 @@ type Test interface {
 // for expected test failures.
 type TestingT struct {
 	Test
+	sync.Synchronizer
 	t      Test
-	wg     mock.WaitGroup
+	wg     sync.WaitGroup
 	expect Expect
 	failed bool
 }
@@ -49,7 +49,7 @@ func NewTestingT(t Test, expect Expect) *TestingT {
 }
 
 // WaitGroup add wait group to unlock in case of a failure.
-func (m *TestingT) WaitGroup(wg mock.WaitGroup) {
+func (m *TestingT) WaitGroup(wg sync.WaitGroup) {
 	m.wg = wg
 }
 
@@ -109,7 +109,7 @@ func (m *TestingT) Fatalf(format string, args ...any) {
 func (m *TestingT) test(test func(*TestingT)) *TestingT {
 	m.t.Helper()
 
-	wg := sync.WaitGroup{}
+	wg := sync.NewWaitGroup()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -103,15 +102,17 @@ func TestRun(t *testing.T) {
 			require.NotEmpty(t, message)
 
 			// Given
-			wg := mock.NewMock(t).WaitGroup()
-			t.WaitGroup(wg)
-			go func() { wg.Add(1); wg.Wait() }()
+			mocks := mock.NewMock(t)
+			mocks.Times(1)
 
 			// When
-			param.test(t)
+			go func() {
+				param.test(t)
+				mocks.Times(-1)
+			}()
 
 			// Then
-			wg.Add(math.MinInt)
+			mocks.Wait()
 		}))
 	}
 }


### PR DESCRIPTION
This pull request is

* Restructuring the `LenientWaitGroup` int an own package under `testing`,
* Fixing the flaky unit test `TestRun` creating a data race in `testing/test/testing_test.go`,
* Adding convenience methods `Times` and `GetDone` to simplify mock-setup-functions, and
* Improving the documentation in `testing/mock/README.md` describing the new features.