### PR TITLE
fix: parallel test support (#8)

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -107,14 +107,37 @@ func (mocks *Mocks) syncWith(t gomock.TestReporter) *Mocks {
 }
 
 // Wait waits for all mock calls registered via `mocks.Times(<#>)` to be
-// consumed before testing continuing. This can be used to support testing of
-// detached `go-routines` using isolated test environments.
+// consumed before testing continuing. This method implements the `WaitGroup`
+// interface to support testing of detached `go-routines` in an isolated
+// [test](../test) environment.
 func (mocks *Mocks) Wait() {
 	mocks.wg.Wait()
 }
 
-// Times is adding creating the expectation that exactly the given number of
-// mock calls setups are consumed via `gomock.Do`.
+// TODO: not needed yet - optional extension.
+//
+// Add adds the given delta on the waiting group handling the expected or
+// consumed mock calls.  This method implements the `WaitGroup` interface to
+// support testing of detached `go-routines` in an isolated [test](../test)
+// environment.
+//
+// func (mocks *Mocks) Add(delta int) {
+// 	mocks.wg.Add(delta)
+// }
+
+// TODO: not needed yet - optional extension.
+//
+// Done removes exactly one expected mock call from the wait group handling the
+// expected or consumed mock calls. This method implements the `WaitGroup`
+// interface to support testing of detached `go-routines` in an isolated
+// [test](../test) environment.
+//
+// func (mocks *Mocks) Done() {
+// 	mocks.wg.Done()
+// }
+
+// Times is creating the expectation that exactly the given number of mock call
+// are consumed via `gomock.Do`.
 func (mocks *Mocks) Times(num int) int {
 	mocks.wg.Add(num)
 	return num
@@ -158,13 +181,21 @@ func (mocks *Mocks) GetDone(numargs int) any {
 	}
 }
 
-// TODO: Reconsider this apporach. Seems not to be helpful yet.
+// TODO: Reconsider this apporach. Seems not to be helpful yet. Test setup
+// functions would look as follows:
+//
+//	func GetTokenX(url string, err error) mock.SetupFunc {
+//	  return mock.Mock(NewMockTokenProvider, func(mock *MockTokenProvider) *gomock.Call {
+//	    return mock.EXPECT().GetToken(url).Return(token)
+//	  })
+//	}
 //
 // Mock defines an advanced mock setup function for exactly one mock call setup
 // by resolving the singleton mock instance and handing it over to the provided
 // function for calling the mock method and providing the return values. The
 // created function automatically sets up the wait group for advanced testing
 // strategies.
+//
 // func Mock[T any](
 // 	creator func(*Controller) *T, caller func(*T) *gomock.Call,
 // ) SetupFunc {
@@ -174,7 +205,7 @@ func (mocks *Mocks) GetDone(numargs int) any {
 // 		value := reflect.ValueOf(call).Elem()
 // 		field := value.FieldByName("methodType")
 // 		ftype := *(*reflect.Type)(unsafe.Pointer(field.UnsafeAddr()))
-// 		return call.Do(mocks.Done(ftype.NumIn()))
+// 		return call.Do(mocks.GetDone(ftype.NumIn()))
 // 	}
 // }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -47,7 +47,9 @@ func MockSetup(t gomock.TestReporter, mockSetup mock.SetupFunc) *mock.Mocks {
 }
 
 func MockValidate(
-	t *test.TestingT, mocks *mock.Mocks, validate func(*test.TestingT, *mock.Mocks), failing bool,
+	t *test.TestingT, mocks *mock.Mocks,
+	validate func(*test.TestingT, *mock.Mocks),
+	failing bool,
 ) {
 	if failing {
 		// we need to execute failing test synchronous, since we setup full
@@ -123,7 +125,9 @@ var testSetupParams = perm.ExpectMap{
 }
 
 func TestSetup(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testSetupParams.Remain(test.ExpectSuccess) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
 			require.NotEmpty(t, message)
 
@@ -144,7 +148,7 @@ func TestSetup(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -153,7 +157,9 @@ var testChainParams = perm.ExpectMap{
 }
 
 func TestChain(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testChainParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
 			require.NotEmpty(t, message)
 
@@ -174,7 +180,7 @@ func TestChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -188,7 +194,9 @@ var testSetupChainParams = perm.ExpectMap{
 }
 
 func TestSetupChain(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testSetupChainParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
 			require.NotEmpty(t, message)
 
@@ -213,12 +221,14 @@ func TestSetupChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
 func TestChainSetup(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testSetupChainParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
 			require.NotEmpty(t, message)
 
@@ -243,7 +253,7 @@ func TestChainSetup(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -263,7 +273,9 @@ var testParallelChainParams = perm.ExpectMap{
 }
 
 func TestParallelChain(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testParallelChainParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
 			require.NotEmpty(t, message)
 
@@ -290,7 +302,7 @@ func TestParallelChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -314,12 +326,12 @@ var testChainSubParams = perm.ExpectMap{
 }
 
 func TestChainSub(t *testing.T) {
+	t.Parallel()
 	perms := testChainSubParams
 	//	perms := PermRemain(testChainSubParams, test.ExpectFailure)
 	for message, expect := range perms {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
-
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -341,7 +353,7 @@ func TestChainSub(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -357,10 +369,10 @@ var testDetachParams = perm.ExpectMap{
 }
 
 func TestDetach(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testDetachParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
-
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -376,7 +388,7 @@ func TestDetach(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, false))
 	}
 }
 
@@ -419,10 +431,10 @@ var testPanicParams = map[string]struct {
 }
 
 func TestPanic(t *testing.T) {
+	t.Parallel()
 	for message, param := range testPanicParams {
+		message, param := message, param
 		t.Run(message, func(t *testing.T) {
-			require.NotEmpty(t, message)
-
 			// Given
 			defer func() {
 				err := recover()
@@ -487,12 +499,10 @@ var testGetSubSliceParams = map[string]struct {
 }
 
 func TestGetSubSlice(t *testing.T) {
+	t.Parallel()
 	for message, param := range testGetSubSliceParams {
+		message, param := message, param
 		t.Run(message, func(t *testing.T) {
-			require.NotEmpty(t, message)
-
-			// Given
-
 			// When
 			slice := mock.GetSubSlice(param.from, param.to, param.slice)
 
@@ -521,10 +531,10 @@ var testGetDoneParams = map[string]struct {
 }
 
 func TestGetDone(t *testing.T) {
+	t.Parallel()
 	for message, param := range testGetDoneParams {
+		message, param := message, param
 		t.Run(message, func(t *testing.T) {
-			require.NotEmpty(t, message)
-
 			// Given
 			mocks := MockSetup(t, nil)
 			mocks.Times(1)

--- a/perm/perm.go
+++ b/perm/perm.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tkrop/testing/mock"
 	"github.com/tkrop/testing/test"
+	"github.com/tkrop/testing/utils/slices"
 )
 
 // ExpectMap defines a map of permutation tests that are expected to either
@@ -58,30 +59,22 @@ func (p *Test) Test(t *test.TestingT, perm []string, expect test.Expect) {
 // Remain calculate and add the missing permutations and add it with
 // expected result to the given permmutation map.
 func (perms ExpectMap) Remain(expect test.Expect) ExpectMap {
-	for key := range perms {
-		Slice(strings.Split(key, "-"), func(perm []string) {
-			key := strings.Join(perm, "-")
-			if _, ok := perms[key]; !ok {
-				perms[key] = expect
-			}
-		}, 0)
-		break // we only need to permutate the first key.
+	cperms := ExpectMap{}
+	for key, value := range perms {
+		cperms[key] = value
 	}
-	return perms
-}
 
-// Slice permutates the given slice starting at the position given by and
-// call the `do` function on each permutation to collect the result. For a full
-// permutation the `index` must start with `0`.
-func Slice[T any](slice []T, do func([]T), index int) {
-	if index <= len(slice) {
-		Slice(slice, do, index+1)
-		for offset := index + 1; offset < len(slice); offset++ {
-			slice[index], slice[offset] = slice[offset], slice[index]
-			Slice(slice, do, index+1)
-			slice[index], slice[offset] = slice[offset], slice[index]
-		}
-	} else {
-		do(slice)
+	// we only need to permutate the first key.
+	for key := range cperms {
+		slices.Permute(strings.Split(key, "-"),
+			func(perm []string) {
+				key := strings.Join(perm, "-")
+				if _, ok := cperms[key]; !ok {
+					cperms[key] = expect
+				}
+			}, 0)
+		break
 	}
+
+	return cperms
 }

--- a/perm/perm_test.go
+++ b/perm/perm_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/tkrop/testing/mock"
 	"github.com/tkrop/testing/perm"
@@ -47,10 +46,10 @@ var testTestParams = perm.ExpectMap{
 }
 
 func TestTest(t *testing.T) {
+	t.Parallel()
 	for message, expect := range testTestParams.Remain(test.ExpectFailure) {
+		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
-
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -67,6 +66,6 @@ func TestTest(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}))
+		}, true))
 	}
 }

--- a/sync/waitgroup.go
+++ b/sync/waitgroup.go
@@ -69,5 +69,11 @@ func (wg *LenientWaitGroup) Done() {
 
 // Wait waits until the work group counter is completely consumed.
 func (wg *LenientWaitGroup) Wait() {
+	defer func() {
+		if err := recover(); err != nil &&
+			err.(string) != "sync: WaitGroup is reused before previous Wait has returned" {
+			panic(err)
+		}
+	}()
 	wg.wg.Wait()
 }

--- a/test/README.md
+++ b/test/README.md
@@ -19,25 +19,57 @@ The main pattern for parameterized unit test looks as follows:
 ```go
 func TestSetupChain(t *testing.T) {
 	for message, param := range testParams {
+		message, param := message, param
 		t.Run(message, test.Run(param.expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
-
 			// Given
 
 			// When
 
 			// Then
-		}))
+		}, false))
 	}
 }
 ```
 
 
-## Isolation pattner for simple tests
+## More isolation pattners
 
-Besides, providing `test.Run(Exepct, func(*test.TestingT)) func(*testing.T)`
-optimized for parameterized test, the package contains two further methods for
+Besides, `test.Run(Exepct, func(*test.TestingT), bool) func(*testing.T)`
+optimized for parameterized test, the package provides two further methods for
 isolation in simpler cases:
 
-* `Failure(func(*test.TestingT) {}) func(*testing.T)`, and
-* `Success(func(*test.TestingT) {}) func(*testing.T)`.
+* `Failure(func(*test.TestingT) {}, bool) func(*testing.T)`, and
+* `Success(func(*test.TestingT) {}, bool) func(*testing.T)`.
+
+All methods provide a `bool`-flag to run test in parallel.
+
+**Note:** there are some general requirements for running test in parallel:
+
+1. The tests *must not modify* environment variables dynamically.
+2. The tests *must not require* reserved service ports and open listeners.
+3. The tests *must not use* [monkey patching](https://github.com/bouk/monkey)
+   to modify commonly used functions,
+4. The tests *must not use* [gock](https://github.com/h2non/gock) for mocking
+   on HTTP transport level, and finally
+5. The tests *must not share* any other resources, e.g. objects or database
+   schemas, that need to be updated during the test execution.
+
+If this conditions hold, the following pattern can bused to support parallel
+test execution in an isolated test environment.
+
+
+```go
+func TestSetupChain(t *testing.T) {
+	t.Parallel()
+	for message, param := range testParams {
+		message, param := message, param
+		t.Run(message, test.Run(param.expect, func(t *test.TestingT) {
+			// Given
+
+			// When
+
+			// Then
+		}, true)) // <-- flag to setup `t.Parallel()` on the test.
+	}
+}
+```

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -8,6 +8,29 @@ import (
 	"github.com/tkrop/testing/mock"
 )
 
+//go:generate mockgen -package=test -destination=mock_iface_test.go -source=testing_test.go  IFace
+
+type IFace interface {
+	CallA(string)
+	CallB(string) string
+}
+
+func CallA(input string) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewMockIFace).EXPECT().
+			CallA(input).Times(mocks.Times(1)).
+			Do(mocks.GetDone(1))
+	}
+}
+
+func CallB(input string, output string) mock.SetupFunc {
+	return func(mocks *mock.Mocks) any {
+		return mock.Get(mocks, NewMockIFace).EXPECT().
+			CallB(input).Return(output).
+			Times(mocks.Times(1)).Do(mocks.GetDone(1))
+	}
+}
+
 var testRunParams = map[string]struct {
 	expect Expect
 	test   func(*TestingT)
@@ -36,6 +59,12 @@ var testRunParams = map[string]struct {
 		expect: ExpectFailure,
 	},
 
+	"run failure": {
+		test: InRun(ExpectFailure,
+			func(t *TestingT) {}),
+		expect: ExpectFailure,
+	},
+
 	"run failure with errorf": {
 		test: InRun(ExpectFailure,
 			func(t *TestingT) { t.Errorf("fail") }),
@@ -45,13 +74,13 @@ var testRunParams = map[string]struct {
 	"run failure with fatalf": {
 		test: InRun(ExpectFailure,
 			func(t *TestingT) { t.Fatalf("fail") }),
-		expect: ExpectSuccess,
+		expect: ExpectFailure,
 	},
 
 	"run failure with failnow": {
 		test: InRun(ExpectFailure,
 			func(t *TestingT) { t.FailNow() }),
-		expect: ExpectSuccess,
+		expect: ExpectFailure,
 	},
 
 	"in success": {
@@ -77,6 +106,11 @@ var testRunParams = map[string]struct {
 		expect: ExpectFailure,
 	},
 
+	"in failure": {
+		test:   InFailure(func(t *TestingT) {}),
+		expect: ExpectFailure,
+	},
+
 	"in failure with errorf": {
 		test: InFailure(
 			func(t *TestingT) { t.Errorf("fail") }),
@@ -86,51 +120,77 @@ var testRunParams = map[string]struct {
 	"in failure with fatalf": {
 		test: InFailure(
 			func(t *TestingT) { t.Fatalf("fail") }),
-		expect: ExpectSuccess,
+		expect: ExpectFailure,
 	},
 
 	"in failure with failnow": {
 		test: InFailure(
 			func(t *TestingT) { t.FailNow() }),
-		expect: ExpectSuccess,
+		expect: ExpectFailure,
 	},
 }
 
-func TestRun(t *testing.T) {
-	for message, param := range testRunParams {
-		t.Run(message, Run(param.expect, func(t *TestingT) {
-			require.NotEmpty(t, message)
+func Call(t *TestingT, mocks *mock.Mocks, expect Expect, test func(*TestingT)) {
+	test(t)
+	if expect == ExpectSuccess {
+		mock.Get(mocks, NewMockIFace).CallA("a")
+	} else {
+		// simulate mock call since consumption of
+		// mock call will creat a random result after
+		// unlocking test thread.
+		mocks.Times(-1)
+	}
+}
 
+func TestRun(t *testing.T) {
+	t.Parallel()
+	for message, param := range testRunParams {
+		message, param := message, param
+		t.Run(message, Run(param.expect, func(t *TestingT) {
 			// Given
-			mocks := mock.NewMock(t)
-			mocks.Times(1)
+			mocks := mock.NewMock(t).Expect(CallA("a"))
 
 			// When
-			go func() {
-				param.test(t)
-				mocks.Times(-1)
-			}()
+			go Call(t, mocks, param.expect, param.test)
 
 			// Then
 			mocks.Wait()
-		}))
+		}, true))
 	}
 }
 
 func TestOther(t *testing.T) {
+	t.Parallel()
 	for message, param := range testRunParams {
+		message, param := message, param
 		switch param.expect {
 		case ExpectSuccess:
 			t.Run(message, Success(func(t *TestingT) {
 				require.NotEmpty(t, message)
-				param.test(t)
-			}))
+
+				// Given
+				mocks := mock.NewMock(t).Expect(CallA("a"))
+
+				// When
+				go Call(t, mocks, param.expect, param.test)
+
+				// Then
+				mocks.Wait()
+			}, true))
 
 		case ExpectFailure:
 			t.Run(message, Failure(func(t *TestingT) {
 				require.NotEmpty(t, message)
-				param.test(t)
-			}))
+
+				// Given
+				mocks := mock.NewMock(t).Expect(CallA("a"))
+
+				// When
+				go Call(t, mocks, param.expect, param.test)
+
+				// Then
+				mocks.Wait()
+			}, true))
 		}
 	}
 }

--- a/utils/slices/slices.go
+++ b/utils/slices/slices.go
@@ -1,0 +1,25 @@
+package slices
+
+// Reverse reverses the given slice.
+func Reverse[T any](slice []T) []T {
+	for i, j := 0, len(slice)-1; i < j; i, j = i+1, j-1 {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	return slice
+}
+
+// Permute permutates the given slice starting at the position given by the
+// index and call the `do` function on each permutation to collect the result.
+// For a full permutation the `index` must start with `0`.
+func Permute[T any](slice []T, do func([]T), i int) {
+	if i <= len(slice) {
+		Permute(slice, do, i+1)
+		for j := i + 1; j < len(slice); j++ {
+			slice[i], slice[j] = slice[j], slice[i]
+			Permute(slice, do, i+1)
+			slice[i], slice[j] = slice[j], slice[i]
+		}
+	} else {
+		do(slice)
+	}
+}


### PR DESCRIPTION
This pull request adds full support for detached *go-routines* and *parallel* tests to the isolated test environment. Effectively it fixes a couple of race conditions that may occur in *parallel* tests and utilizes the `cleanup` handler of `*testing.T` to automatically capture the missing `gomock`-calls. In addition, it fixes the problem of test waiting forever for concurrent mock calls (when waiting) and not capturing missing calls in the isolated test environment.