### PR TITLE
feat: provide gock controller and storage (#9)

### DIFF
--- a/MAKEFILE.md
+++ b/MAKEFILE.md
@@ -50,6 +50,13 @@ make test-unit   # executes only unit tests by setting the short flag
 make test-cover  # opens the test coverage report in the browser
 ```
 
+In addition, it is possible to restrict test target execution to packages,
+files and test cases as follows:
+
+* For a single package use `make test-(unit|all) <package> ...`).
+* For a single test file (`make test[-(unit|all) <package>/<file>_test.go ...`).
+* For a single test case (`make test[-(unit|all) <package>/<test-name> ...`).
+
 
 ### Linter targets
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Testing
 
 The testing projects contains a couple of small opinionated extensions for
-[Golang](https://go.dev/) and [Gomock](https://github.com/golang/mock) to
-simplify and enable complicated unit and component tests.
+[Golang][go] and [Gomock][gomock] to simplify and enable complicated unit and
+component tests.
 
 * [mock](mock) provides the means to setup a simple chain or a complex network
   of expected mock calls with minimal effort. This makes it easy to extend the
@@ -12,6 +12,10 @@ simplify and enable complicated unit and component tests.
   and safely check whether a test fails as expected. This is primarily very
   handy to validate a test framework as provided by the [mock](mock) package
   but may be handy in other cases too.
+
+* [gock](gock) provides a drop-in extension for [Gock][gock] consisting of a
+  controller and a mock storage that allows to run tests isolated. This allows
+  to parallelize simple test and parameterized tests.
 
 * [perm](perm) provides a small framework to simplify permutation tests, i.e.
   a consistent test set where conditions can be checked in all known orders
@@ -33,3 +37,7 @@ versioning for changes.
 If you like to contribute, please create an issue and/or pull request with a
 proper description of your proposal or contribution. I will review it and
 provide feedback on it.
+
+[go]: https://go.dev/ "Golang"
+[gomock]: https://github.com/golang/mock "GoMock"
+[gock]: https://github.com/h2non/gock "Gock"

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,14 @@ go 1.19
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
+	golang.org/x/text v0.3.3
+	gopkg.in/h2non/gock.v1 v1.1.2
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,13 +3,19 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -26,6 +32,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -35,6 +42,8 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gock/README.md
+++ b/gock/README.md
@@ -1,0 +1,73 @@
+# Usage patterns of testing/gock
+
+This package provides a small controller and mock storage to isolate testing of
+HTTP request/response cycles extending [Gock][gock]. Since framework is focused
+on testing it does not support the networking and observation features of
+[Gock][gock] and requires manual transport interception, however, the interface
+is mainly compatible with.
+
+
+## Migration from Gock to Tock
+
+Migration from [Gock][gock] to this package is straigt forward. You can just
+add the controller creation as at the begin of your test giving it the name
+`gock` and hand it over to all methods creating HTTP request/response mocks. The
+mock creation than happens as usual.
+
+```go
+func MyTest(t *testing.T) {
+	gock := tock.Controller(t)
+
+	...
+
+	gock.New("http://foo.com").Get("/bar").Times(1).
+		Reply(200).BodyString("result")
+
+	...
+}
+```
+
+Since the controller does not intercept all transports by default, you need to
+setup transport interception manually. This can happen in three different ways.
+If you have access to the HTTP request/response client, you can either use the
+usual `InterceptClient` (and `RestoreClient`) methods.
+
+```go
+func MyTest(t *testing.T) {
+	gock := tock.Controller(t)
+
+	...
+
+	client := &http.Client{}
+	gock.InterceptClient(client)
+	defer gock.RestoreClient(client) // optional
+
+	...
+}
+```
+
+Some customized HTTP clients e.g. [resty][resty] offer the ability to set the
+transport manually based on `http.RoundTripper` interface. The controller
+supports customized HTTP clients by implementing `http.RoundTripper` so that
+you can utilize their setup methods.
+
+```go
+func MyTest(t *testing.T) {
+	gock := tock.Controller(t)
+
+	...
+
+	client := resty.New()
+	client.setTransport(gock)
+
+	...
+}
+```
+
+As last resort, you can also intercept the `http.DefaultTransport`, however,
+this is not advised, since it will destroy the test isolation that is goal of
+this wrapper framework. In this case you should use
+[gock][gock] directly.
+
+[gock]: https://github.com/h2non/gock "Gock"
+[resty]: https://github.com/go-resty/resty "Resty"

--- a/gock/common_test.go
+++ b/gock/common_test.go
@@ -1,0 +1,40 @@
+package gock
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+var errAny = errors.New("any error")
+
+// NewFooMatcher creates a special foo matcher.
+func NewFooMatcher() *gock.MockMatcher {
+	matcher := gock.NewEmptyMatcher()
+	matcher.Add(func(req *http.Request, ereq *gock.Request) (bool, error) {
+		if req.URL.Scheme == "https" {
+			return true, errAny
+		}
+		return true, nil
+	})
+	matcher.Add(func(req *http.Request, ereq *gock.Request) (bool, error) {
+		return req.URL.Host == "foo.com", nil
+	})
+	matcher.Add(func(req *http.Request, ereq *gock.Request) (bool, error) {
+		return req.URL.Path == "/baz" || req.URL.Path == "/bar", nil
+	})
+	return matcher
+}
+
+// NewRoundTrippertError creates the same round trip error usually returned in
+// case of a transport error. This method is used for validating tests that are
+// replacing the transport against the error `RoundTripper` via
+// `NewErrorRoundTripper`.
+func NewRoundTrippertError(method string, URL string, err error) error {
+	op := cases.Title(language.Und).String(method)
+	return &url.Error{Op: op, URL: URL, Err: err}
+}

--- a/gock/controller.go
+++ b/gock/controller.go
@@ -1,0 +1,112 @@
+package gock
+
+import (
+	"net/http"
+
+	gock "gopkg.in/h2non/gock.v1"
+
+	"github.com/tkrop/testing/test"
+)
+
+// Transport is a small transport implementation delegating requests to the
+// owning HTTP request/response mock controller.
+type Transport struct {
+	// controller is the responsible HTTP request/response mock controller.
+	controller *Controller
+	// transport encapsulates the original transport interface for delegation.
+	transport http.RoundTripper
+}
+
+// NewTransport creates a new *Transport with no responders.
+func NewTransport(
+	controller *Controller, transport http.RoundTripper,
+) *Transport {
+	return &Transport{
+		controller: controller,
+		transport:  transport,
+	}
+}
+
+// RoundTrip delegates to the controller `RoundTrip` method.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.controller.RoundTrip(req)
+}
+
+// Controller is a Gock based HTTP request/response mock controller.
+type Controller struct {
+	// The attached test context.
+	t test.Test
+	// MockStore the attached HTTP request/response mock storage.
+	MockStore *MockStore
+}
+
+// NewControler creates a new HTTP request/response mock controller.
+func NewControler(t test.Test) *Controller {
+	ctrl := &Controller{
+		t:         t,
+		MockStore: NewStore(gock.NewMatcher()),
+	}
+	if c, ok := ctrl.t.(test.Cleanuper); ok {
+		c.Cleanup(func() {
+			ctrl.cleanup()
+		})
+	}
+	return ctrl
+}
+
+// New creates and registers a new HTTP request/response mock with given full
+// qualified URI and default settings. It returns the request builder for
+// setup of HTTP request and response mock details.
+func (ctrl *Controller) New(uri string) *gock.Request {
+	return ctrl.MockStore.NewMock(uri).Request()
+}
+
+// InterceptClient allows to intercept HTTP traffic of a custom http.Client that
+// uses a non default http.Transport/http.RoundTripper implementation.
+func (ctrl *Controller) InterceptClient(client *http.Client) {
+	if _, ok := client.Transport.(*Transport); ok {
+		return
+	}
+	client.Transport = NewTransport(ctrl, client.Transport)
+}
+
+// RestoreClient allows to disable and restore the original transport in the
+// given http.Client.
+func (ctrl *Controller) RestoreClient(client *http.Client) {
+	if transport, ok := client.Transport.(*Transport); ok {
+		client.Transport = transport.transport
+	}
+}
+
+// RoundTrip receives HTTP requests and matches them against the registered
+// HTTP request/response mocks. If a match is found it is used to construct the
+// response, else the request is tracked as unmatched. If networing is enabled,
+// the orginal transport is used to handle the request to .
+//
+// This method implements the `http.RoundTripper` interface and is used by
+// attaching the controller to a `http.client` via `SetTransport`.
+func (ctrl *Controller) RoundTrip(req *http.Request) (*http.Response, error) {
+	// find matching mock for the incoming request.
+	mock, err := ctrl.MockStore.Match(req)
+	if err != nil {
+		return nil, err
+	} else if mock == nil {
+		return nil, gock.ErrCannotMatch
+	}
+	defer ctrl.MockStore.Clean()
+
+	return gock.Responder(req, mock.Response(), nil)
+}
+
+// Finish checks if all the HTTP request/response mocks that were expected to
+// be called were called. This function is registered with the test controller
+// and will be called when the test is finished.
+func (ctrl *Controller) cleanup() {
+	if pending := ctrl.MockStore.Pending(); len(pending) != 0 {
+		for _, call := range pending {
+			ctrl.t.Errorf("missing call(s) to %v", call)
+		}
+		ctrl.t.Errorf("aborting test due to missing call(s)")
+	}
+	ctrl.MockStore.Flush()
+}

--- a/gock/controller_test.go
+++ b/gock/controller_test.go
@@ -1,0 +1,79 @@
+package gock
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/tkrop/testing/test"
+)
+
+var testControllerParams = map[string]struct {
+	url         string
+	expectMatch test.Expect
+	expectError error
+}{
+	"match with bar": {
+		url:         "http://foo.com/bar",
+		expectMatch: test.ExpectSuccess,
+	},
+	"match with baz": {
+		url:         "http://foo.com/baz",
+		expectMatch: test.ExpectSuccess,
+	},
+	"missing host": {
+		url:         "http://bar.com/baz",
+		expectError: gock.ErrCannotMatch,
+	},
+	"missing path": {
+		url:         "http://foo.com/foo",
+		expectError: gock.ErrCannotMatch,
+	},
+	"missing schema": {
+		url:         "https://foo.com/bar",
+		expectError: errAny,
+	},
+}
+
+func TestController(t *testing.T) {
+	t.Parallel()
+	for message, param := range testControllerParams {
+		message, param := message, param
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			tt := test.NewTestingT(t, param.expectMatch)
+			ctrl := NewControler(tt)
+			ctrl.MockStore.Matcher = NewFooMatcher()
+			ctrl.New("http://foo.com").Get("/bar").Times(1).Reply(200)
+			client := &http.Client{}
+
+			// When
+			ctrl.RestoreClient(client)
+			ctrl.InterceptClient(client)
+			ctrl.InterceptClient(client)
+			response, err := client.Get(param.url)
+			ctrl.RestoreClient(client)
+
+			// Then
+			if param.expectError != nil {
+				assert.Equal(t, NewRoundTrippertError(
+					http.MethodGet, param.url, param.expectError), err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if param.expectMatch {
+				assert.Equal(t, 200, response.StatusCode)
+				assert.True(t, ctrl.MockStore.IsDone(), "mock done")
+			} else {
+				assert.False(t, ctrl.MockStore.IsDone(), "mock not done")
+			}
+			tt.Run(func(t *test.TestingT) {
+				ctrl.cleanup()
+			})
+		})
+	}
+}

--- a/gock/store.go
+++ b/gock/store.go
@@ -1,0 +1,146 @@
+package gock
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+// MockStore store for HTTP request/response mocks.
+type MockStore struct {
+	mocks []gock.Mock
+	mutex sync.RWMutex
+	// Matcher template used when creating new HTTP request/response mocks.
+	Matcher *gock.MockMatcher
+}
+
+// NewStore creates a new mock registry for HTTP request/respone mocks. If nil
+// is provided as matcher the default matcher is used.
+func NewStore(matcher *gock.MockMatcher) *MockStore {
+	if matcher != nil {
+		return &MockStore{Matcher: matcher}
+	}
+	return &MockStore{Matcher: gock.NewMatcher()}
+}
+
+// NewMock creates and registers a new HTTP request/response mock with default
+// settings and returns the mock.
+func (s *MockStore) NewMock(uri string) gock.Mock {
+	res := gock.NewResponse()
+	req := gock.NewRequest()
+	req.URLStruct, res.Error = url.Parse(uri)
+
+	// Create the new mock expectation
+	mock := gock.NewMock(req, res)
+	mock.SetMatcher(s.Matcher.Clone())
+	s.Register(mock)
+	return mock
+}
+
+// Register registers a new HTTP request/response mocks in the current stack.
+func (s *MockStore) Register(mock gock.Mock) {
+	if s.Exists(mock) {
+		return
+	}
+
+	// Expose mock in request/response for delegation
+	mock.Request().Mock = mock
+	mock.Response().Mock = mock
+
+	// Make ops thread safe
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// Registers the mock in the global store
+	s.mocks = append(s.mocks, mock)
+}
+
+// Match matches the given `http.Request` with the registered HTTP request
+// mocks. It is returning the mock that matches or an error, if a matching
+// function fails. If no HTTP mock request matches nothing is returned.
+func (s *MockStore) Match(req *http.Request) (gock.Mock, error) {
+	for _, mock := range s.All() {
+		matches, err := mock.Match(req)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			return mock, nil
+		}
+	}
+	return nil, nil
+}
+
+// IsDone returns true if all the registered  HTTP request/response mocks have
+// been triggered successfully.
+func (s *MockStore) IsDone() bool {
+	return !s.IsPending()
+}
+
+// IsPending returns true if there are pending HTTP request/response mocks.
+func (s *MockStore) IsPending() bool {
+	return len(s.Pending()) > 0
+}
+
+// All returns the current list of registered HTTP request/response mocks.
+func (s *MockStore) All() []gock.Mock {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.mocks
+}
+
+// Pending returns a slice of the pending HTTP request/response mocks.
+func (s *MockStore) Pending() []gock.Mock {
+	s.Clean()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.mocks
+}
+
+// Exists checks if the given HTTP request/response mocks is already registered.
+func (s *MockStore) Exists(m gock.Mock) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	for _, mock := range s.mocks {
+		if mock == m {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove removes a registered HTTP request/response mocks by reference.
+func (s *MockStore) Remove(m gock.Mock) {
+	for i, mock := range s.mocks {
+		if mock == m {
+			s.mutex.Lock()
+			s.mocks = append(s.mocks[:i], s.mocks[i+1:]...)
+			s.mutex.Unlock()
+		}
+	}
+}
+
+// Flush flushes the current stack of registered HTTP request/response mocks.
+func (s *MockStore) Flush() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.mocks = []gock.Mock{}
+}
+
+// Clean cleans the store removing disabled or obsolete HTTP request/response
+// mocks.
+func (s *MockStore) Clean() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	buf := []gock.Mock{}
+	for _, mock := range s.mocks {
+		if mock.Done() {
+			continue
+		}
+		buf = append(buf, mock)
+	}
+	s.mocks = buf
+}

--- a/gock/store_test.go
+++ b/gock/store_test.go
@@ -1,0 +1,233 @@
+package gock
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreRegister(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+
+	// When
+	mock := store.NewMock("foo")
+
+	// Then
+	assert.Len(t, store.mocks, 1)
+	assert.Equal(t, store.mocks[0], mock)
+	assert.Equal(t, mock.Request().Mock, mock)
+	assert.Equal(t, mock.Response().Mock, mock)
+
+	// When
+	store.Register(mock)
+	assert.Len(t, store.mocks, 1)
+	assert.Equal(t, store.mocks[0], mock)
+}
+
+func TestStoreGetAll(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	mock := store.NewMock("foo")
+
+	// WHen
+	mocks := store.All()
+
+	// Then
+	assert.Len(t, store.mocks, 1)
+	assert.Len(t, mocks, 1)
+	assert.Equal(t, mocks[0], mock)
+}
+
+func TestStoreExists(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	mock := store.NewMock("foo")
+
+	// When
+	exists := store.Exists(mock)
+
+	assert.Len(t, store.mocks, 1)
+	assert.True(t, exists, "mock exists")
+}
+
+func TestStorePending(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(NewFooMatcher())
+	mock := store.NewMock("foo")
+	done := store.NewMock("http://foo.com")
+	done.Request().Get("/bar")
+	done.Match(&http.Request{Method: http.MethodGet, URL: &url.URL{
+		Scheme: "http", Host: "foo.com", Path: "/baz",
+	}})
+
+	// Then
+	assert.Len(t, store.mocks, 2)
+
+	// When
+	pending := store.Pending()
+
+	// Then
+	assert.Len(t, store.mocks, 1)
+	assert.Equal(t, store.mocks, pending)
+	assert.Equal(t, store.mocks[0], mock)
+}
+
+func TestStoreIsPending(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	store.NewMock("foo")
+
+	// When
+	pending := store.IsPending()
+
+	// Then
+	assert.True(t, pending, "mock pending")
+
+	// When
+	store.Flush()
+	pending = store.IsPending()
+
+	// Then
+	assert.False(t, pending, "no mock pending")
+}
+
+func TestStoreIsDone(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	store.NewMock("foo")
+
+	// When
+	done := store.IsDone()
+
+	// Then
+	assert.False(t, done, "mocks not done")
+
+	// When
+	store.Flush()
+	done = store.IsDone()
+
+	// Then
+	assert.True(t, done, "mocks done")
+}
+
+func TestStoreRemove(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	mock := store.NewMock("foo")
+
+	// When
+	exists := store.Exists(mock)
+
+	// Then
+	assert.Len(t, store.mocks, 1)
+	assert.True(t, exists, "mock exists")
+
+	// When
+	store.Remove(mock)
+	exists = store.Exists(mock)
+
+	// Then
+	assert.False(t, exists, "mock exists not")
+
+	// When
+	store.Remove(mock)
+	exists = store.Exists(mock)
+
+	// Then
+	assert.False(t, exists, "mock exists not")
+}
+
+func TestStoreFlush(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	store := NewStore(nil)
+	mock1 := store.NewMock("foo")
+	mock2 := store.NewMock("foo")
+
+	// Then
+	assert.Len(t, store.All(), 2)
+	assert.True(t, store.Exists(mock1), "mock1 exists")
+	assert.True(t, store.Exists(mock2), "mock2 exists")
+
+	// When
+	store.Flush()
+
+	// Then
+	assert.Len(t, store.All(), 0)
+	assert.False(t, store.Exists(mock1), "mock1 exists not")
+	assert.False(t, store.Exists(mock2), "mock2 exists not")
+}
+
+var testMatchParams = map[string]struct {
+	url         string
+	expectMatch bool
+	expectError error
+}{
+	"match with bar": {
+		url:         "http://foo.com/bar",
+		expectMatch: true,
+	},
+	"match with baz": {
+		url:         "http://foo.com/baz",
+		expectMatch: true,
+	},
+	"missing host": {
+		url: "http://bar.com/baz",
+	},
+	"missing path": {
+		url: "http://foo.com/foo",
+	},
+	"missing schema": {
+		url:         "https://foo.com/bar",
+		expectError: errAny,
+	},
+}
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+	for message, param := range testMatchParams {
+		message, param := message, param
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			store := NewStore(NewFooMatcher())
+			mock := store.NewMock(param.url)
+
+			// When
+			uri, _ := url.Parse(param.url)
+			match, err := store.Match(
+				&http.Request{URL: uri})
+
+			// Then
+			if param.expectError != nil {
+				assert.Equal(t, param.expectError, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if param.expectMatch {
+				assert.Equal(t, match, mock)
+			} else {
+				assert.Nil(t, match)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request provides first approach of a drop-in extension for [Gock][gock] consisting of a controller and a mock storage that allows to run tests isolated. This allows to parallelize simple test and parameterized tests. The final goal is to seemingly integrate Gock-like with the gomock wrapper provided via the mock framework.

[gock]: https://github.com/h2non/gock "Gock"