### PR TITLE
feat: integrate gock with mock framework (#10)

### DIFF
--- a/gock/README.md
+++ b/gock/README.md
@@ -69,5 +69,32 @@ this is not advised, since it will destroy the test isolation that is goal of
 this wrapper framework. In this case you should use
 [gock][gock] directly.
 
+
+## Integration with `mock`-framework
+
+The `Gock`-controller framework supports a simple integration with the
+[mock](../mock) framework for [gomock][gomock]: it simply provides constructor
+that accepts the `gomock`-controller. Using constructor, it is possible to
+create the usual setup methods similar as described in
+[mock](../mock#generic-mock-service-call-pattern).
+
+```go
+func GockCall(
+	url, path string, input..., status int, output..., error,
+) mock.SetupFunc {
+    return func(mocks *Mocks) any {
+        mock.Get(mocks, gock.NewGock).New(url).Get(path).Times(1).
+			Reply(status)...
+		return nil
+    }
+}
+```
+
+**Note:** While this already nicely integrates the mock controller creation,
+call setup, and validation, it currently provides no support for call order
+validation as [GoMock][gomock] supports it.
+
+
+[gomock]: https://github.com/golang/mock "GoMock"
 [gock]: https://github.com/h2non/gock "Gock"
 [resty]: https://github.com/go-resty/resty "Resty"

--- a/gock/controller.go
+++ b/gock/controller.go
@@ -3,6 +3,7 @@ package gock
 import (
 	"net/http"
 
+	"github.com/golang/mock/gomock"
 	gock "gopkg.in/h2non/gock.v1"
 
 	"github.com/tkrop/testing/test"
@@ -40,8 +41,17 @@ type Controller struct {
 	MockStore *MockStore
 }
 
-// NewControler creates a new HTTP request/response mock controller.
-func NewControler(t test.Test) *Controller {
+// NewGock creates a new HTTP request/response mock controller from the given
+// go mock controller.
+func NewGock(ctrl *gomock.Controller) *Controller {
+	if t, ok := ctrl.T.(test.Test); ok {
+		return NewController(t)
+	}
+	panic("gock not supported by test setup")
+}
+
+// NewController creates a new HTTP request/response mock controller.
+func NewController(t test.Test) *Controller {
 	ctrl := &Controller{
 		t:         t,
 		MockStore: NewStore(gock.NewMatcher()),

--- a/gock/controller_test.go
+++ b/gock/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 
@@ -46,7 +47,7 @@ func TestController(t *testing.T) {
 
 			// Given
 			tt := test.NewTestingT(t, param.expectMatch)
-			ctrl := NewControler(tt)
+			ctrl := NewGock(gomock.NewController(tt))
 			ctrl.MockStore.Matcher = NewFooMatcher()
 			ctrl.New("http://foo.com").Get("/bar").Times(1).Reply(200)
 			client := &http.Client{}

--- a/mock/README.md
+++ b/mock/README.md
@@ -41,7 +41,7 @@ future.
 ```go
 func ServiceCall(input..., output..., error) mock.SetupFunc {
     return func(mocks *Mocks) any {
-        return Get(mocks, NewServiceMock).EXPECT().
+        return mock.Get(mocks, NewServiceMock).EXPECT().
             ServiceCall(input...).Return(output..., error).
 			Times(mocks.Times(1)).Do(mocks.GetDone(<#input-args>))
     }
@@ -215,10 +215,10 @@ parallel:
 
 1. The tests *must not modify* environment variables dynamically.
 2. The tests *must not require* reserved service ports and open listeners.
-3. The tests *must not use* [monkey patching](https://github.com/bouk/monkey)
-   to modify commonly used functions,
-4. The tests *must not use* [gock](https://github.com/h2non/gock) for mocking
-   on HTTP transport level, and finally
+3. The tests *must not use* [Gock][gock] for mocking on HTTP transport level
+   (please use the internal [gock](../gock)-controller package),
+4. The tests *must not use* [monkey patching][monkey] to modify commonly used
+   functions, e.g. `time.Now()`, and finaly
 5. The tests *must not share* any other resources, e.g. objects or database
    schemas, that need to be updated during the test execution.
 
@@ -253,3 +253,6 @@ func TestUnitCall(t *testing.T) {
 
 **Note:** In the above pattern the setup for parallel tests hidden in the setup
 of the isolated [test](../test) environment.
+
+[gock]: https://github.com/h2non/gock "Gock"
+[monkey]: https://github.com/bouk/monkey "Monkey Patching"

--- a/test/README.md
+++ b/test/README.md
@@ -47,10 +47,10 @@ All methods provide a `bool`-flag to run test in parallel.
 
 1. The tests *must not modify* environment variables dynamically.
 2. The tests *must not require* reserved service ports and open listeners.
-3. The tests *must not use* [monkey patching](https://github.com/bouk/monkey)
-   to modify commonly used functions,
-4. The tests *must not use* [gock](https://github.com/h2non/gock) for mocking
-   on HTTP transport level, and finally
+3. The tests *must not use* [Gock][gock] for mocking on HTTP transport level
+   (please use the internal [gock](../gock)-controller package),
+4. The tests *must not use* [monkey patching][monkey] to modify commonly used
+   functions, e.g. `time.Now()`, and finaly
 5. The tests *must not share* any other resources, e.g. objects or database
    schemas, that need to be updated during the test execution.
 
@@ -73,3 +73,6 @@ func TestSetupChain(t *testing.T) {
 	}
 }
 ```
+
+[gock]: https://github.com/h2non/gock "Gock"
+[monkey]: https://github.com/bouk/monkey "Monkey Patching"


### PR DESCRIPTION
This pull request integrates the `gock`-controller with the `mock`-framework providing a first simple solution. While it nicely integrates with the mock framework for controller creation, call setup, and call validation, it is currently not possible to validate the call order.