### PR TITLE
feat: apply more linters and fix violations (#13)

### DIFF
--- a/MAKEFILE.md
+++ b/MAKEFILE.md
@@ -65,7 +65,8 @@ as well as with fixing the linter problems - if possible.
 
 ```bash
 make lint      # short cut to execute 'lint-src lint-api'
-make lint-src  # lints the go-source code excluding generated code
+make lint-all  # lints the go-source code using all linters
+make lint-src  # lints the go-source code using selected rules
 make lint-api  # lints the api specifications in '/zalando-apis'
 make format    # formats the code to fix some linter violations
 ```

--- a/gock/common_test.go
+++ b/gock/common_test.go
@@ -34,7 +34,7 @@ func NewFooMatcher() *gock.MockMatcher {
 // case of a transport error. This method is used for validating tests that are
 // replacing the transport against the error `RoundTripper` via
 // `NewErrorRoundTripper`.
-func NewRoundTrippertError(method string, URL string, err error) error {
+func NewRoundTrippertError(method string, _url string, err error) error {
 	op := cases.Title(language.Und).String(method)
-	return &url.Error{Op: op, URL: URL, Err: err}
+	return &url.Error{Op: op, URL: _url, Err: err}
 }

--- a/gock/controller.go
+++ b/gock/controller.go
@@ -91,7 +91,7 @@ func (ctrl *Controller) RestoreClient(client *http.Client) {
 // RoundTrip receives HTTP requests and matches them against the registered
 // HTTP request/response mocks. If a match is found it is used to construct the
 // response, else the request is tracked as unmatched. If networing is enabled,
-// the orginal transport is used to handle the request to .
+// the original transport is used to handle the request to .
 //
 // This method implements the `http.RoundTripper` interface and is used by
 // attaching the controller to a `http.client` via `SetTransport`.

--- a/gock/store.go
+++ b/gock/store.go
@@ -16,7 +16,7 @@ type MockStore struct {
 	Matcher *gock.MockMatcher
 }
 
-// NewStore creates a new mock registry for HTTP request/respone mocks. If nil
+// NewStore creates a new mock registry for HTTP request/response mocks. If nil
 // is provided as matcher the default matcher is used.
 func NewStore(matcher *gock.MockMatcher) *MockStore {
 	if matcher != nil {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -43,9 +43,9 @@ func (m DetachMode) String() string {
 }
 
 type (
-	// Call alias for `gomock.Call`
+	// Call alias for `gomock.Call`.
 	Call = gomock.Call
-	// Controller alias for `gomock.Controller`
+	// Controller alias for `gomock.Controller`.
 	Controller = gomock.Controller
 
 	// chain is the type to signal that mock calls must and will be orders in a
@@ -186,7 +186,7 @@ func (mocks *Mocks) GetFunc(numargs int, fn func()) any {
 	}
 }
 
-// TODO: Reconsider this apporach. Seems not to be helpful yet. Test setup
+// TODO: Reconsider this approach. Seems not to be helpful yet. Test setup
 // functions would look as follows:
 //
 //	func GetTokenX(url string, err error) mock.SetupFunc {
@@ -275,7 +275,7 @@ func Parallel(fncalls ...func(*Mocks) any) func(*Mocks) any {
 }
 
 // Detach detach given mock call setup using given detach mode. It is possible
-// to detach the mock call from the preceeding mock calls (`Head`), from the
+// to detach the mock call from the preceding mock calls (`Head`), from the
 // succeeding mock calls (`Tail`), or from both as used in `Setup`.
 func Detach(mode DetachMode, fncall func(*Mocks) any) func(*Mocks) any {
 	return func(mocks *Mocks) any {
@@ -302,7 +302,7 @@ func Detach(mode DetachMode, fncall func(*Mocks) any) func(*Mocks) any {
 func Sub(from, to int, fncall func(*Mocks) any) func(*Mocks) any {
 	return func(mocks *Mocks) any {
 		calls := fncall(mocks)
-		switch calls := any(calls).(type) {
+		switch calls := calls.(type) {
 		case *Call:
 			inOrder([]*Call{}, calls)
 			return GetSubSlice(from, to, []any{calls})
@@ -357,13 +357,13 @@ func getPos[T any](pos int, calls []T) int {
 	return len - 1
 }
 
-// chainCalls joins arbitray slices, single mock calls, and parallel mock calls
+// chainCalls joins arbitrary slices, single mock calls, and parallel mock calls
 // into a single mock call slice and slice of mock slices. If the provided mock
 // calls do not contain mock calls or slices of them, the join fails with a
 // `panic`.
 func chainCalls(calls []chain, more ...any) []chain {
 	for _, call := range more {
-		switch call := any(call).(type) {
+		switch call := call.(type) {
 		case *Call:
 			calls = append(calls, call)
 		case []chain:
@@ -388,7 +388,7 @@ func chainCalls(calls []chain, more ...any) []chain {
 // predecessor and return the mock call as next anchor. The created order
 // depends on the actual type of the mock call (slice).
 func inOrder(anchors []*Call, call any) []*Call {
-	switch call := any(call).(type) {
+	switch call := call.(type) {
 	case *Call:
 		return inOrderCall(anchors, call)
 	case []parallel:

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -67,14 +67,14 @@ func SetupPermTestABC(mocks *mock.Mocks) *perm.Test {
 	iface := mock.Get(mocks, NewMockIFace)
 	return perm.NewTest(mocks,
 		perm.TestMap{
-			"a": func(t *test.TestingT) { iface.CallA("a") },
+			"a": func(*test.TestingT) { iface.CallA("a") },
 			"b1": func(t *test.TestingT) {
 				assert.Equal(t, "c", iface.CallB("b"))
 			},
 			"b2": func(t *test.TestingT) {
 				assert.Equal(t, "d", iface.CallB("b"))
 			},
-			"c": func(t *test.TestingT) { iface.CallA("c") },
+			"c": func(*test.TestingT) { iface.CallA("c") },
 		})
 }
 
@@ -82,8 +82,8 @@ func SetupPermTestABCD(mocks *mock.Mocks) *perm.Test {
 	iface := mock.Get(mocks, NewMockIFace)
 	return perm.NewTest(mocks,
 		perm.TestMap{
-			"a": func(t *test.TestingT) { iface.CallA("a") },
-			"b": func(t *test.TestingT) { iface.CallA("b") },
+			"a": func(*test.TestingT) { iface.CallA("a") },
+			"b": func(*test.TestingT) { iface.CallA("b") },
 			"c": func(t *test.TestingT) {
 				assert.Equal(t, "d", iface.CallB("c"))
 			},
@@ -97,16 +97,16 @@ func SetupPermTestABCDEF(mocks *mock.Mocks) *perm.Test {
 	iface := mock.Get(mocks, NewMockIFace)
 	return perm.NewTest(mocks,
 		perm.TestMap{
-			"a": func(t *test.TestingT) { iface.CallA("a") },
-			"b": func(t *test.TestingT) { iface.CallA("b") },
+			"a": func(*test.TestingT) { iface.CallA("a") },
+			"b": func(*test.TestingT) { iface.CallA("b") },
 			"c": func(t *test.TestingT) {
 				assert.Equal(t, "d", iface.CallB("c"))
 			},
 			"d": func(t *test.TestingT) {
 				assert.Equal(t, "e", iface.CallB("d"))
 			},
-			"e": func(t *test.TestingT) { iface.CallA("e") },
-			"f": func(t *test.TestingT) { iface.CallA("f") },
+			"e": func(*test.TestingT) { iface.CallA("e") },
+			"f": func(*test.TestingT) { iface.CallA("f") },
 		})
 }
 
@@ -131,7 +131,7 @@ func TestSetup(t *testing.T) {
 	for message, expect := range testSetupParams.Remain(test.ExpectSuccess) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
+			t.Parallel()
 
 			// Given
 			perm := strings.Split(message, "-")
@@ -150,7 +150,7 @@ func TestSetup(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -164,7 +164,7 @@ func TestChain(t *testing.T) {
 	for message, expect := range testChainParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
+			t.Parallel()
 
 			// Given
 			perm := strings.Split(message, "-")
@@ -183,7 +183,7 @@ func TestChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -202,7 +202,7 @@ func TestSetupChain(t *testing.T) {
 	for message, expect := range testSetupChainParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
+			t.Parallel()
 
 			// Given
 			perm := strings.Split(message, "-")
@@ -225,7 +225,7 @@ func TestSetupChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -235,7 +235,7 @@ func TestChainSetup(t *testing.T) {
 	for message, expect := range testSetupChainParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
+			t.Parallel()
 
 			// Given
 			perm := strings.Split(message, "-")
@@ -258,7 +258,7 @@ func TestChainSetup(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -283,7 +283,7 @@ func TestParallelChain(t *testing.T) {
 	for message, expect := range testParallelChainParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
-			require.NotEmpty(t, message)
+			t.Parallel()
 
 			// Given
 			perm := strings.Split(message, "-")
@@ -308,7 +308,7 @@ func TestParallelChain(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -339,6 +339,8 @@ func TestChainSub(t *testing.T) {
 	for message, expect := range perms {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
+			t.Parallel()
+
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -360,7 +362,7 @@ func TestChainSub(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -381,6 +383,8 @@ func TestDetach(t *testing.T) {
 	for message, expect := range testDetachParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
+			t.Parallel()
+
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -396,7 +400,7 @@ func TestDetach(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, false))
+		}))
 	}
 }
 
@@ -444,6 +448,8 @@ func TestPanic(t *testing.T) {
 	for message, param := range testPanicParams {
 		message, param := message, param
 		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
 			// Given
 			defer func() {
 				err := recover()
@@ -513,6 +519,8 @@ func TestGetSubSlice(t *testing.T) {
 	for message, param := range testGetSubSliceParams {
 		message, param := message, param
 		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
 			// When
 			slice := mock.GetSubSlice(param.from, param.to, param.slice)
 
@@ -546,6 +554,8 @@ func TestGetDone(t *testing.T) {
 	for message, param := range testGetFuncParams {
 		message, param := message, param
 		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
 			// Given
 			mocks := MockSetup(t, nil)
 			mocks.Times(1)
@@ -554,39 +564,7 @@ func TestGetDone(t *testing.T) {
 			}
 
 			// When
-			fncall := mocks.GetDone(param.numargs)
-			switch param.numargs {
-			case 0:
-				fncall.(func())()
-			case 1:
-				fncall.(func(any))(nil)
-			case 2:
-				fncall.(func(any, any))(nil, nil)
-			case 3:
-				fncall.(func(any, any, any))(nil, nil, nil)
-			case 4:
-				fncall.(func(any, any, any, any))(nil, nil, nil, nil)
-			case 5:
-				fncall.(func(
-					any, any, any, any, any,
-				))(nil, nil, nil, nil, nil)
-			case 6:
-				fncall.(func(
-					any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil)
-			case 7:
-				fncall.(func(
-					any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil)
-			case 8:
-				fncall.(func(
-					any, any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil, nil)
-			case 9:
-				fncall.(func(
-					any, any, any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil, nil, nil)
-			}
+			call(mocks.GetDone(param.numargs), param.numargs)
 
 			// Then
 			mocks.Wait()
@@ -603,6 +581,8 @@ func TestGetPanic(t *testing.T) {
 	for message, param := range testGetFuncParams {
 		message, param := message, param
 		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+
 			// Given
 			mocks := MockSetup(t, nil)
 			mocks.Times(1)
@@ -620,42 +600,47 @@ func TestGetPanic(t *testing.T) {
 			}()
 
 			// When
-			fncall := mocks.GetPanic(param.numargs, "panic-test")
-			switch param.numargs {
-			case 0:
-				fncall.(func())()
-			case 1:
-				fncall.(func(any))(nil)
-			case 2:
-				fncall.(func(any, any))(nil, nil)
-			case 3:
-				fncall.(func(any, any, any))(nil, nil, nil)
-			case 4:
-				fncall.(func(any, any, any, any))(nil, nil, nil, nil)
-			case 5:
-				fncall.(func(
-					any, any, any, any, any,
-				))(nil, nil, nil, nil, nil)
-			case 6:
-				fncall.(func(
-					any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil)
-			case 7:
-				fncall.(func(
-					any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil)
-			case 8:
-				fncall.(func(
-					any, any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil, nil)
-			case 9:
-				fncall.(func(
-					any, any, any, any, any, any, any, any, any,
-				))(nil, nil, nil, nil, nil, nil, nil, nil, nil)
-			}
+			call(mocks.GetPanic(param.numargs, "panic-test"), param.numargs)
 
 			// Then
 			assert.Fail(t, "not paniced on not supported argument number")
 		})
+	}
+}
+
+func call(fncall any, args int) {
+	switch args {
+	case 0:
+		fncall.(func())()
+	case 1:
+		fncall.(func(any))(nil)
+	case 2:
+		fncall.(func(any, any))(nil, nil)
+	case 3:
+		fncall.(func(any, any, any))(nil, nil, nil)
+	case 4:
+		fncall.(func(any, any, any, any))(nil, nil, nil, nil)
+	case 5:
+		fncall.(func(
+			any, any, any, any, any,
+		))(nil, nil, nil, nil, nil)
+	case 6:
+		fncall.(func(
+			any, any, any, any, any, any,
+		))(nil, nil, nil, nil, nil, nil)
+	case 7:
+		fncall.(func(
+			any, any, any, any, any, any, any,
+		))(nil, nil, nil, nil, nil, nil, nil)
+	case 8:
+		fncall.(func(
+			any, any, any, any, any, any, any, any,
+		))(nil, nil, nil, nil, nil, nil, nil, nil)
+	case 9:
+		fncall.(func(
+			any, any, any, any, any, any, any, any, any,
+		))(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	default:
+		panic("not supported")
 	}
 }

--- a/perm/perm_test.go
+++ b/perm/perm_test.go
@@ -29,9 +29,9 @@ func SetupPermTestABC(mocks *mock.Mocks) *perm.Test {
 	iface := mock.Get(mocks, NewMockIFace)
 	return perm.NewTest(mocks,
 		perm.TestMap{
-			"a": func(t *test.TestingT) { iface.CallA("a") },
-			"b": func(t *test.TestingT) { iface.CallA("b") },
-			"c": func(t *test.TestingT) { iface.CallA("c") },
+			"a": func(*test.TestingT) { iface.CallA("a") },
+			"b": func(*test.TestingT) { iface.CallA("b") },
+			"c": func(*test.TestingT) { iface.CallA("c") },
 		})
 }
 
@@ -51,6 +51,8 @@ func TestTest(t *testing.T) {
 	for message, expect := range testTestParams.Remain(test.ExpectFailure) {
 		message, expect := message, expect
 		t.Run(message, test.Run(expect, func(t *test.TestingT) {
+			t.Parallel()
+
 			// Given
 			perm := strings.Split(message, "-")
 			mockSetup := mock.Chain(
@@ -67,6 +69,6 @@ func TestTest(t *testing.T) {
 
 			// Then
 			test.Test(t, perm, expect)
-		}, true))
+		}))
 	}
 }

--- a/test/testing_test.go
+++ b/test/testing_test.go
@@ -3,8 +3,6 @@ package test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/tkrop/testing/mock"
 )
 
@@ -148,6 +146,8 @@ func TestRun(t *testing.T) {
 	for message, param := range testRunParams {
 		message, param := message, param
 		t.Run(message, Run(param.expect, func(t *TestingT) {
+			t.Parallel()
+
 			// Given
 			mocks := mock.NewMock(t).Expect(CallA("a"))
 
@@ -156,7 +156,7 @@ func TestRun(t *testing.T) {
 
 			// Then
 			mocks.Wait()
-		}, true))
+		}))
 	}
 }
 
@@ -168,7 +168,7 @@ func TestOther(t *testing.T) {
 		switch param.expect {
 		case ExpectSuccess:
 			t.Run(message, Success(func(t *TestingT) {
-				require.NotEmpty(t, message)
+				t.Parallel()
 
 				// Given
 				mocks := mock.NewMock(t).Expect(CallA("a"))
@@ -178,11 +178,11 @@ func TestOther(t *testing.T) {
 
 				// Then
 				mocks.Wait()
-			}, true))
+			}))
 
 		case ExpectFailure:
 			t.Run(message, Failure(func(t *TestingT) {
-				require.NotEmpty(t, message)
+				t.Parallel()
 
 				// Given
 				mocks := mock.NewMock(t).Expect(CallA("a"))
@@ -192,7 +192,7 @@ func TestOther(t *testing.T) {
 
 				// Then
 				mocks.Wait()
-			}, true))
+			}))
 		}
 	}
 }


### PR DESCRIPTION
This pull request integrates `golangci-lint` to apply more linters by default. It also fixes the violations to comply with the new linters.